### PR TITLE
Changed social media icons in the homepage darkmode

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -12,13 +12,14 @@ html[data-theme="light"] {
 }
 
 html[data-theme="dark"] {
-  --bg-icon: rgba(255, 255, 255, 0.9);
-  --col-icon-twitter: #1da1f2;
-  --col-icon-dribbble: #ea4c89;
-  --col-icon-linkedin: #0e76a8;
-  --col-icon-medium: #00ab6c;
-  --col-icon-kaggle: #41aff3;
-  --col-icon-github: #24292e;
+  --bg-icon:#000;
+  --col-icon-twitter:#1da1f2;
+  --col-icon-dribbble:#ea4c89;
+  --col-icon-linkedin:#0e76a8;
+  --col-icon-medium:#00ab6c;
+  --col-icon-kaggle:#41aff3;
+  --col-icon-github:#fff;
+  --shadow-col:#1de9b6;
 }
 
 /* Particle effect*/
@@ -170,6 +171,9 @@ html[data-theme="dark"] {
 .social-icon.github:after {
   background-color: #24292e;
   box-shadow: var(--github);
+}
+.social-icon.github:hover {
+  background-color:#fff!important;
 }
 
 .social-icon.linkedin:after {


### PR DESCRIPTION

# Related Issuse or bug
  - social media icons in the homepage changed to blend with the darkmode design.

Fixes: #261 [issue number that will be closed through this PR]

# Proposed Changes
 - I made the changes so that they can blend in more effectively and look good with the darkmode background.
  
# Screenshots

 Original  
<img width="948" alt="prvs" src="https://user-images.githubusercontent.com/68493940/102059667-34722d80-3e17-11eb-8c21-3a8e9503a428.PNG">
 | Updated
<img width="948" alt="Portfo" src="https://user-images.githubusercontent.com/68493940/102059696-3f2cc280-3e17-11eb-92f8-81b83c39c7b7.PNG">

 :--------------------: |:--------------------:
 **original screenshot** | **updated screenshot **|
