### PR TITLE
social media icons position fixed in mobile view

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -108,7 +108,7 @@ let footer = $(`
     </div>
     <!-- Social media icons for footer -->
 
-<div class="social-icons-footer mx-lg-auto">
+<div class="social-icons-footer mx-lg-auto" style="display:flex">
   <a class="social-icon-footer twitter" href="" target="_blank" rel="author">
     <i class="fab fa-twitter"></i>
       </a>


### PR DESCRIPTION
# Related Issues or bug
  - The position of social media handles icons are not perfect in the mobile view.
  
Fixes: #367 

# Proposed Changes
 - I have the Fixed position of social media handles in the footer in mobile view.
  
# Screenshots

 Original:-
 
![Screenshot of John Doe _ Home](https://user-images.githubusercontent.com/59636849/103171880-81252200-4875-11eb-94e8-1a636d2e2608.jpg)

Updated:-

![Screenshot of John Doe _ Home (1)](https://user-images.githubusercontent.com/59636849/103171884-8d10e400-4875-11eb-804b-d89ca436d5f8.jpg)
