### PR TITLE
Limited the dark mode toggler ability to the toggler button itself

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -215,6 +215,12 @@ p {
     transform 500ms cubic-bezier(0.26, 2, 0.46, 0.71);
   margin-top: -1.5em;
   margin-left: -7em;
+  cursor: pointer;
+  pointer-events: all;
+}
+
+.theme-switch {
+  pointer-events: none;
 }
 
 .toggle-checkbox:checked ~ .toggle-slot .toggle-button {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -181,18 +181,24 @@ bodyElement.append(footer);
 var checkbox = document.querySelector("input[name=theme]");
 if (checkbox) {
   let a = localStorage.getItem("theme");
-  document.documentElement.setAttribute("data-theme", a);
+  document.documentElement.setAttribute("data-theme", a); // setting the initial theme to light
 
   if (localStorage.getItem("theme") === "dark") {
     checkbox.checked = true;
   }
+
   let toggler = document.querySelector('.toggle-button');
+  // listening for click on toggler
   toggler.addEventListener("click", () => {
     if (checkbox.checked) {
+      // if theme is dark then on the toggler click we have to make it light
       trans();
       document.documentElement.setAttribute("data-theme", "light");
       localStorage.setItem("theme", "light");
-    } else {
+    } else { 
+      /*
+      if there is click on toggler and if theme is light (initially it will be light) then the should convert to dark
+      */
       trans();
       document.documentElement.setAttribute("data-theme", "dark");
       localStorage.setItem("theme", "dark");

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -197,7 +197,7 @@ if (checkbox) {
       localStorage.setItem("theme", "light");
     } else { 
       /*
-      if there is click on toggler and if theme is light (initially it will be light) then the should convert to dark
+      if there is click on toggler and if theme is light (initially it will be light) then the theme should convert to dark
       */
       trans();
       document.documentElement.setAttribute("data-theme", "dark");

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -186,15 +186,16 @@ if (checkbox) {
   if (localStorage.getItem("theme") === "dark") {
     checkbox.checked = true;
   }
-  checkbox.addEventListener("change", function () {
-    if (this.checked) {
-      trans();
-      document.documentElement.setAttribute("data-theme", "dark");
-      localStorage.setItem("theme", "dark");
-    } else {
+  let toggler = document.querySelector('.toggle-button');
+  toggler.addEventListener("click", () => {
+    if (checkbox.checked) {
       trans();
       document.documentElement.setAttribute("data-theme", "light");
       localStorage.setItem("theme", "light");
+    } else {
+      trans();
+      document.documentElement.setAttribute("data-theme", "dark");
+      localStorage.setItem("theme", "dark");
     }
   });
 


### PR DESCRIPTION
Fixes: #360 

# Proposed Changes
 - Limited the ability of theme toggling to the toggle button itself
 
# Additional Info
  - Added the limitation because there were unexpected overflows that were breaking the cursor look.
  
# Clips of changes
**Before**
https://user-images.githubusercontent.com/49204837/103173415-dc104680-4880-11eb-8339-f9046aefab2a.mp4

**After**

https://user-images.githubusercontent.com/49204837/103173424-e6cadb80-4880-11eb-8b15-7e1c237bb5a3.mp4

