### PR TITLE
Added links to the social icons in the index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,12 +59,12 @@
             </div>
             <br/>
             <span style="display: inline;" >I am into <span class="animated-text"
-                data-words="Designing, UI/UX, Cloud Computing, Web Development, Open Source, Mentoring"></span>
+                data-words="Designing, UI/UX, Cloud Computing, Web Development, Machine Learning, Open Source, Mentoring"></span>
             </span>
             <div>
                 <div class="social-icons">
 
-                    <a class="socialicon twitter" href="" target="_blank" rel="author">
+                    <a class="socialicon twitter" href="https://www.twitter.com" target="_blank" rel="author">
                         <!-- SVG code for twitter icon -->
                         <svg class="twitter-icon" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
                             xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 500 500" enable-background="new 0 0 500 500"
@@ -122,11 +122,11 @@
                         </svg>
                     </a>
 
-                    <a class="socialicon dribbble" href="" target="_blank" rel="author">
+                    <a class="socialicon dribbble" href="https://www.dribbble.com" target="_blank" rel="author">
                         <i class="fab fa-dribbble"></i>
                     </a>
 
-                    <a class="socialicon linkedin" href="" target="_blank" rel="author">
+                    <a class="socialicon linkedin" href="https://www.linkedin.com" target="_blank" rel="author">
                         <svg class="linkedin-icon" xmlns="http://www.w3.org/2000/svg" width="35" viewBox="0 0 24 24" fill="#0e76a8"
                             stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="feather feather-linkedin">
                             <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path>
@@ -135,15 +135,15 @@
                         </svg>
                     </a>
 
-                    <a class="socialicon medium" href="" target="_blank" rel="author">
+                    <a class="socialicon medium" href="https://www.medium.com" target="_blank" rel="author">
                         <i class="fab fa-medium-m"></i>
                     </a>
 
-                    <a class="socialicon kaggle" href="" target="_blank" rel="author">
+                    <a class="socialicon kaggle" href="https://www.kaggle.com" target="_blank" rel="author">
                         <i class="fab fa-kaggle"></i>
                     </a>
 
-                    <a class="socialicon instagram" href="" target="_blank" rel="author">
+                    <a class="socialicon instagram" href="https://www.instagram.com" target="_blank" rel="author">
                         <!-- svg code for instagram icon -->
                         <svg class="instagram-icon" x="0px" y="0px" viewBox="0 0 202.5 202.5" style="enable-background:new 0 0 202.5 202.5;">
                             <circle id="littleCircle" class="st0" cx="101" cy="101.5" r="18.9" />
@@ -154,7 +154,7 @@
                         </svg>
                     </a>
 
-                    <a class="socialicon github" href="" target="_blank" rel="author">
+                    <a class="socialicon github" href="https://www.github.com" target="_blank" rel="author">
                         <!-- SVG code for Github icon -->
                         <svg class="github-icon" width="45px" height="45px" viewBox="0 0 300 300">
                             <!-- body -->


### PR DESCRIPTION
I have added links for the social media icons on the index page. Previously upon clicking on the icons, the users were brought back to the default home page, which at first seemed a bit unusual. But now, the users will be directed to the official websites of respective social media icons.
Also, since one social media icon was of Kaggle, which on opening gives an overview of Machine Learning. So I added Machine Learning as well to the data words of our default user-John Doe.