### PR TITLE
Scroll to the top btn (#665)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -98,7 +98,53 @@ body {
   background-color: var(--bg);
 }
 
-/* Top button */
+/* Scroll to Top button */
+#btnScrollToTop {
+	width: 50px;
+	height: 50px;
+  background-color: #6C63FF;
+  margin: 8px;
+  border: none;
+	border-radius: 50%;
+  box-shadow: 2px 5px 5px rgba(0, 0, 0, 0.3);
+  text-decoration: none;  
+	position: fixed;
+  outline: none;
+  bottom: 10px;
+  right: 10px;
+	animation: up 1.5s infinite;
+	-webkit-animation: up 1.5s infinite;
+}
+
+/*
+---------------------------------------
+   SCROLL TO TOP BUTTON MICROANIMATION
+---------------------------------------
+*/
+
+@keyframes up {
+	0% {
+		transform: translate(0);
+	}
+	20% {
+		transform: translateY(-15px);
+	}
+	40% {
+		transform: translate(0);
+	}
+}
+
+@-webkit-keyframes up {
+	0% {
+		transform: translate(0);
+	}
+	20% {
+		transform: translateY(-15px);
+	}
+	40% {
+		transform: translate(0);
+	}
+}
 
 /* smooth scrolling to top */
 html {
@@ -370,7 +416,7 @@ html {
     FOOTER SECTION
 ------------------------
 */
-
+/* Also have a look at the scroll to top button if changing footer's height (below upArrow in app.js) */
 .footer{
   padding-top: 10px;
   font-family: "Poppins", sans-serif;
@@ -767,6 +813,9 @@ form{
         text-align: center;
         transform: translateY(25%);
      }
+      #btnScrollToTop {
+        display: none;
+     }      
    }
 
    
@@ -782,6 +831,9 @@ form{
       text-align: center;
       transform: translateY(25%);
    }
+    #btnScrollToTop {
+          display: none;
+   }
   }
 
    @media (max-width:  375px) {
@@ -795,6 +847,9 @@ form{
       height: 120vh;
       text-align: center;
       transform: translateY(25%);
+   }
+    #btnScrollToTop {
+          display: none;
    }
   }
 
@@ -815,6 +870,7 @@ form{
      margin-top: 6rem;
 
    }
-
-   
+    #btnScrollToTop {
+          display: none;
+   }
   }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -245,13 +245,51 @@ let footer = $(`
 </footer>
 `);
 
+//"Scroll to top" button
+let upArrow = $(`
+  <button id="btnScrollToTop" onclick="scrollToTop()"><i class="fas fa-2x fa-angle-up"></i></button>
+  <link rel="stylesheet" type="text/css" href="./css/style.css" />
+  })
+`)
 
+//function for the "Scroll To Top" button to detect the footer
+$(document).ready(function(){
+  $(window).scroll(function() {
+    console.log($(window).scrollTop());
+    //The button will be hidden until we scroll more than the window's height
+    if ($(window).scrollTop() < $(window).height()) {
+      $("#btnScrollToTop").css("visibility","hidden");
+    }
+    else {
+      $("#btnScrollToTop").css("visibility","visible");
+      //The button will change it's color when it hits the footer
+      if($(window).scrollTop() + $(window).height() > $(document).height() - 838) {
+        // 838 should be changed if footer's height is changed so that the button changes it's color exactly when it hits the footer (preferably 14 less than the computer height of the footer)
+        $("#btnScrollToTop").css("background-color","#43D1Af");
+      }
+      else {
+        $("#btnScrollToTop").css("background-color","#6C63FF");
+      }
+    }
+  })
+});
+
+//function to scroll to top
+const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    left: 0,
+    behavior: "smooth"
+  });
+}
 
 // Window Loads
 $(function() {
     let bodyElement = $(`body`);
     bodyElement.prepend(header);
     bodyElement.append(footer);
+    bodyElement.append(upArrow);
+    $("#btnScrollToTop").css("visibility","hidden");
 
     //toggler hamburger functions
     const menuBtn = document.querySelector('.navbar-toggler');


### PR DESCRIPTION
#665 
### **Initial changes**
- Reduced the size
- Added the microanimation which was suggested
- Removed the outline which appeared after the click
- The color of the button changes when it hits the footer

### **New changes (suggested by @anushbhatia yesterday)**
- When we move to the top, the button vanishes
- The button will be visible only when you scroll more than your window's height
- The button is removed in mobile view (<768 px screen width) 