### PR TITLE
bugFix: remove scroll-bar during preload

### DIFF
--- a/assets/css/preloader.css
+++ b/assets/css/preloader.css
@@ -1,4 +1,8 @@
 /* preloader */
+.no-scroll-preload {
+    overflow: hidden;
+}
+
 :root {
     --atom-size: 350px;
     /* --atom-color-hex: #0d00ff; */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -371,3 +371,11 @@ window.addEventListener("storage", function () {
     app.setAttribute("light-mode", "light");
   }
 }, false);
+
+// Function to remove scroll bar during preload
+$(window).on('load', function() {
+
+  $('.loader-container').fadeOut(2500, function() {
+    $('.no-scroll-preload').css('overflow', 'visible');
+  });
+});

--- a/design.html
+++ b/design.html
@@ -51,7 +51,7 @@
         <link rel="stylesheet" href="assets/css/design.css">
     </head>
 
-    <body>
+    <body class="no-scroll-preload">
 
         <!-- loader -->
         <div class="loader-container">

--- a/education.html
+++ b/education.html
@@ -45,7 +45,7 @@
     <script defer src="./assets/js/dynamicTitle.js"></script>
 </head>
 
-<body>
+<body class="no-scroll-preload">
     <!-- loader -->
     <div class="loader-container">
         <div class="preloader-text">

--- a/experience.html
+++ b/experience.html
@@ -45,7 +45,7 @@
 
 </head>
 
-<body>
+<body class="no-scroll-preload">
     <!-- loader -->
     <div class="loader-container">
         <div class="preloader-text">

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <script defer src="./assets/js/dynamicTitle.js"></script>
 </head>
 
-<body>
+<body class="no-scroll-preload">
     <!-- loader -->
     <div class="loader-container">
         <div class="preloader-text">

--- a/projects.html
+++ b/projects.html
@@ -51,7 +51,7 @@
     <script defer src="./assets/js/dynamicTitle.js"></script>
 </head>
 
-<body>
+<body class="no-scroll-preload">
     <!-- loader -->
     <div class="loader-container">
         <div class="preloader-text">
@@ -63,7 +63,7 @@
             <div class="electron-omega"></div>
 		</div>
    </div>
-
+add 
 
     <div class="container pt-5" style="width: 100%; min-height: 80%">
         <section style="height: 70vh">

--- a/research.html
+++ b/research.html
@@ -56,7 +56,7 @@
   </script> -->
 </head>
 
-<body>
+<body class="no-scroll-preload">
 
     <!-- loader -->
     <div class="loader-container">

--- a/travel_temp.html
+++ b/travel_temp.html
@@ -55,7 +55,7 @@
         <link rel="stylesheet" href="assets/css/travel_temp.css">
     </head>
 
-    <body>
+    <body class="no-scroll-preload">
 
         <!-- loader -->
         <div class="loader-container">


### PR DESCRIPTION
<h3>Fixes #882</h3>

## Work Done:

 - Fixed the Scroll-bar bug in the preloader page
 - Updated index.html, preloader.css and app.js

## Relevant Screenshots and GIFs
<p>This is how it looked previously: </p>
<img src="https://user-images.githubusercontent.com/63910374/124979236-6a475f80-e050-11eb-97ee-72b2a6196a23.png" width="600">
 
<p>After fixing the bug, it looks like this: </p>
<img src="https://user-images.githubusercontent.com/63910374/124981098-ca3f0580-e052-11eb-886b-c3b2053423a3.gif" width="600">

