### PR TITLE
fixed #942

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -377,7 +377,7 @@ window.addEventListener("storage", function () {
   } else {
     app.setAttribute("light-mode", "light");
   }
-}, false);
+}, window.localStorage.clear());
 
 // Function to remove scroll bar during preload
 $(window).on('load', function() {


### PR DESCRIPTION
Fixed issue [ Dark Mode ] Sometimes the toggle works exactly opposite as it should be. ( under OpenSourceDay21 )
The error was coming when we used to refresh while being on dark mode. This occurred because the localStorage was not getting cleared every time we refreshed. 
Now when you toggle, everything will be perfect.



