### PR TITLE
#1010 Addressed hover link visibility in dark mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -301,6 +301,10 @@ html[light-mode="dark"] {
     color: rgba(255, 255, 255, 0.5);
 }
 
+.dark-theme .nav-link:hover{
+color: #ffffff !important;
+}
+
 .dark-theme .first,
 .dark-theme .second,
 .dark-theme .third {


### PR DESCRIPTION
See branch Iss#1010 for added code to style.css to make hover link color light against dark background.

Resolves #1010. #1010 was created from conversation in #956, so #956 can also be completed. 