### PR TITLE
Replaced Resume Section in the Navbar to Blogs

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,7 +20,7 @@ let header = $(`
    <li class="nav-item nav-item-hover"><a class="nav-link" href="projects.html">Projects</a></li>
    <li class="nav-item nav-item-hover"><a class="nav-link" href="research.html">Research</a></li>
    <li class="nav-item nav-item-hover"><a class="nav-link" href="education.html">Education</a></li>
-   <li class="nav-item nav-item-hover"><a class="nav-link" href="./assets/docs/john_doe.pdf" target="_blank">Resume</a></li>
+   <li class="nav-item nav-item-hover"><a class="nav-link" href="https://hashnode.com/" target="_blank">Blogs</a></li>
    <li class="nav-item">
    <input type="checkbox" class="dark_toggler" aria-label="Toggle Light Mode" onclick="toggle_light_mode()">
    </li>


### PR DESCRIPTION
Fixes #1022 

### Worked Done: 

- Replaced the Resume Section in the Navbar to Blogs 
- On clicking the Blogs section in Navbar hashnode.com is opened in new tab. 