### PR TITLE
added box shadow to the navbar in the light theme only

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -237,6 +237,7 @@ html {
     color: #000000;
     background-color: #fff;
     z-index: 2;
+    box-shadow: 0 2px 2px rgb(230, 230, 230);
 }
 
 /* Dark Mode toggle switch button */
@@ -292,6 +293,7 @@ html[light-mode="dark"] {
 .dark-theme {
     background-color: #2b2a2A;
     transition: background-color .3s;
+    box-shadow: 0 0 0;
 }
 
 .dark-theme .navbar-nav .nav-link,


### PR DESCRIPTION
Fixes: #1052 

Added box-shadow to the navbar in the light theme.
**(Before)**
![image](https://user-images.githubusercontent.com/49204837/135198193-d0ed8351-799c-4e6e-95f6-6ff3f2e85fbe.png)

**(After)**
![image](https://user-images.githubusercontent.com/49204837/135198227-306dccd3-f764-480b-a013-60ed3104aab7.png)

**Note:** Didn't add it in the dark theme because it was okay there.