### PR TITLE
fixed navbar links for light theme #1198

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -376,7 +376,7 @@ color: #ffffff !important;
 
 /*
 -------------------------------------
-  NAV BAR HIGHTLIGHTING
+  NAV BAR HIGHLIGHTING
 --------------------------------------
 */
 
@@ -426,6 +426,14 @@ color: #ffffff !important;
   .bike {
       display: none;
   }
+}
+
+/* navbar hover for light mode */
+html[light-mode="light"] .nav-link:hover{
+  color: #000000 !important;
+}
+html[light-mode="light"] .navbar-brand:hover{
+  color: #000000 !important;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59331821/155840716-10406122-1a8b-4a8c-ac5d-663bca9fe67d.png)

Set the colour black on hover for both navbar links and navbar brand