### PR TITLE
github icon: fix github icon not displaying properly in dark mode

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -301,6 +301,10 @@ a.socialicon {
    GITHUB MICROANIMATION
 --------------------------
 */
+html[light-mode="dark"] .github-icon{
+  fill: #ffff;
+}
+
 .github-icon {
   width: 40px;
   margin-left: 12px;


### PR DESCRIPTION
![3](https://user-images.githubusercontent.com/9593259/156133161-c5d1816f-2d2b-43c4-966e-8b17330b7dfc.png)
