### PR TITLE
Shifted buttons to bottom in Research page

### DIFF
--- a/assets/css/research.css
+++ b/assets/css/research.css
@@ -383,7 +383,7 @@ body {
   margin: 1em 10px 0 10px;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items:center;
 }
 
 .button:hover,

--- a/assets/js/research.js
+++ b/assets/js/research.js
@@ -176,9 +176,9 @@ const fillData = () => {
                     <div class="rConferences"> ${conferences} 
                         <div class="researchY">${researchYr}</div>
                     </div>
-        
+                      <br><br><br>
                     <!--CITE BUTTON-->
-                    <div class="d-flex" style="margin-right:5%;">
+                    <div class="d-flex">
                         <button class="button button-accent button-small text-right button-abstract " type="button" data-toggle="collapse" data-target="#${absbox}" aria-expanded="false" aria-controls="${absbox}">
                             ABSTRACT
                         </button>


### PR DESCRIPTION
_**Issue no : #1203**_

-->Shifted buttons to bottom of boxes.


![image](https://user-images.githubusercontent.com/82203261/156416142-4ba5bde4-cd94-49c6-b9b5-ce8c933e7cf0.png)
