### PR TITLE
Added Stackoverflow Social Icon with animation

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -9,10 +9,10 @@ html[data-theme="light"] {
  inset #4D4D4D -2px -2px 4px;
   --col-bd-icon:transparent;
   --bg-icon: #fff;
-   --bg1-color: #fff;
+  --bg1-color: #fff;
   --col-icon-dribbble: #ea4c89;
   --col-icon-linkedin: #0e76a8;
-  --col-icon-kaggle: #41aff3;  
+  --col-icon-kaggle: #41aff3;
   --col-icon-instagram: rgb(201, 94, 174);
   --col-icon-mail:rgb(209, 82, 82);
   --col-icon-google-scholar:#3cba54;
@@ -147,13 +147,6 @@ html[light-mode="dark"] .socialicon{
   background-color: #141516;
 }
 
-.kaggle i {
-  margin: auto;
-  font-size: 24px;
-  z-index: 1;
-  transition: var(--trans-props);
-}
-
 .socialicon.kaggle{
   color:var(--col-icon-kaggle);
 }
@@ -174,8 +167,7 @@ html[light-mode="dark"] .socialicon{
   box-shadow: var(--kaggle);
 }
 
-
- /*
+/*
 ---------------------------
    LINKEDIN MICROANIMATION
 ---------------------------
@@ -424,7 +416,27 @@ html[light-mode="dark"] .github-icon{
     }
   }
   
-  
+/*
+--------------------------------
+   STACKOVERFLOW MICROANIMATION
+--------------------------------
+*/
+
+.stackoverflow-icon {
+  height: 60%;
+  align-self: center;
+  margin: 5px 0px 0px 3px;
+}
+
+.stackoverflow:hover .wings{
+  transform-origin: bottom right;
+  animation: stack 1s infinite alternate;
+}		
+
+@keyframes stack{
+  0% { transform: rotate(10deg); }
+  100% { transform: rotate(-2deg); }
+ }
 
 /*
 ----------------------------

--- a/index.html
+++ b/index.html
@@ -178,6 +178,14 @@
                             </svg>
                         </a>
 
+                        <a class="socialicon stackoverflow" href="" target="_blank" rel="author">
+                            <!-- <i class="fab fa-stack-overflow"></i> -->
+                            <svg class="stackoverflow-icon" xmlns="http://www.w3.org/2000/svg" width="60px" height="30px" fill="#ef8236" viewBox="0 0 16 20">
+                                <path d="M12.412 14.572V10.29h1.428V16H1v-5.71h1.428v4.282h9.984z" fill="#ef8236"></path>
+                                <path class="wings" d="M3.857 13.145h7.137v-1.428H3.857v1.428zM10.254 0 9.108.852l4.26 5.727 1.146-.852L10.254 0zm-3.54 3.377 5.484 4.567.913-1.097L7.627 2.28l-.914 1.097zM4.922 6.55l6.47 3.013.603-1.294-6.47-3.013-.603 1.294zm-.925 3.344 6.985 1.469.294-1.398-6.985-1.468-.294 1.397z" fill="#ef8236"></path> 
+                            </svg>
+                        </a>
+
                         <a class="socialicon github" href="" target="_blank" rel="author">
                             <!-- SVG code for Github icon -->
                             <svg class="github-icon" width="45px" height="45px" viewBox="0 0 300 300">


### PR DESCRIPTION
# Work Done:

- Added Stackoverflow Social Icon with Animation
- Removed the class (.kaggle i) from home.css as it was redundant and the same as the class (.socialicon i).

# Relevant Screenshots/Gifs

![awesome-portfolio-stackoverflow-icon](https://user-images.githubusercontent.com/9162827/196270565-09ff4b6a-4156-4546-85f6-c7d948d295c6.gif)
